### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ RoxygenNote: 7.2.3
 Biarch: true
 Depends: 
     R (>= 4.0.0),
-    rstan (>= 2.18.1)
+    rstan (>= 2.26.0)
 Imports: 
     methods,
     Rcpp (>= 0.12.0),
@@ -49,8 +49,8 @@ LinkingTo:
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    StanHeaders (>= 2.18.0),
-    rstan (>= 2.18.1)
+    StanHeaders (>= 2.26.0),
+    rstan (>= 2.26.0)
 SystemRequirements: GNU make, C++17
 License: MIT + file LICENSE
 Suggests: 

--- a/inst/stan/betabinom.stan
+++ b/inst/stan/betabinom.stan
@@ -1,8 +1,8 @@
 data {
   int<lower=1> K; // number of  arms
   int<lower=0> N; // number of trials
-  int<lower=1, upper=K> z[N]; // arm on trial n
-  int<lower=0, upper=1> y[N]; // outcome on trial n
+  array[N] int<lower=1, upper=K> z; // arm on trial n
+  array[N] int<lower=0, upper=1> y; // outcome on trial n
   real <lower=0> pistar;
   int <lower=0> pess;
 }

--- a/inst/stan/logisticdummy.stan
+++ b/inst/stan/logisticdummy.stan
@@ -9,9 +9,9 @@ data {
   int <lower=0> beta1_nu;
   
   int<lower=1> N;  // total number of observations
-  int y[N];  // response variable
+  array[N] int y;  // response variable
   int<lower=1> K;  // number of population-level effects
-  int <lower=0, upper=K> z[N]; // arm applied on trial n
+  array[N] int <lower=0, upper=K> z; // arm applied on trial n
    matrix[N, K] x;  // population-level design matrix
 }
 transformed data {

--- a/inst/stan/randomeffect.stan
+++ b/inst/stan/randomeffect.stan
@@ -2,9 +2,9 @@ data {
   int<lower=1> N;  // number of patients
   int<lower=1> K;  // number of treatment arms
   int<lower=1> groupmax;  // number of time points
-  int<lower=1, upper=K> X[N];  // predictor variable
-  int<lower=0, upper=1> Y[N];  // response variable
-  int<lower=1> group[N];
+  array[N] int<lower=1, upper=K> X;  // predictor variable
+  array[N] int<lower=0, upper=1> Y;  // response variable
+  array[N] int<lower=1> group;
 }
 
 parameters {


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
